### PR TITLE
Move TH1IntegrateWithPartialBins from C++ to Python

### DIFF
--- a/src/hdtv/rootext/fit/LinkDef.h
+++ b/src/hdtv/rootext/fit/LinkDef.h
@@ -25,6 +25,5 @@
 #pragma link C++ class HDTV::Fit::TheuerkaufFitter+;
 #pragma link C++ class HDTV::Fit::EEPeak+;
 #pragma link C++ class HDTV::Fit::EEFitter+;
-#pragma link C++ function HDTV::TH1IntegrateWithPartialBins;
 
 #endif

--- a/src/hdtv/rootext/fit/Util.cc
+++ b/src/hdtv/rootext/fit/Util.cc
@@ -44,14 +44,4 @@ std::string GetFuncUniqueName(const char *prefix, void *ptr) {
   return name.str();
 }
 
-double TH1IntegrateWithPartialBins(const TH1 *spec, const double xmin, const double xmax) {
-  const TAxis *axis = spec->GetXaxis();
-  const int bmin = axis->FindBin(xmin);
-  const int bmax = axis->FindBin(xmax);
-  double integral = spec->Integral(bmin, bmax);
-  integral -= spec->GetBinContent(bmin) * (xmin - axis->GetBinLowEdge(bmin)) / axis->GetBinWidth(bmin);
-  integral -= spec->GetBinContent(bmax) * (axis->GetBinUpEdge(bmax) - xmax) / axis->GetBinWidth(bmax);
-  return integral;
-}
-
 } // end namespace HDTV

--- a/src/hdtv/rootext/fit/Util.hh
+++ b/src/hdtv/rootext/fit/Util.hh
@@ -31,8 +31,6 @@ namespace HDTV {
 
 std::string GetFuncUniqueName(const char *prefix, void *ptr);
 
-double TH1IntegrateWithPartialBins(const TH1 *spec, const double xmin, const double xmax);
-
 } // end namespace HDTV
 
 #endif


### PR DESCRIPTION
ROOT.HDTV.TH1IntegrateWithPartialBins() is only used in histogram.py.
Since it is a small and easy function, it can be implemented directly in PyROOT and does not need to be compiled.

---

This patch isn't covered by the test suite. ~I'm also unsure how to trigger the function manually.~ Manual tested (https://github.com/janmayer/hdtv/pull/52#issuecomment-3796839728)