### PR TITLE
Fix legacy syntax for compatibility with latest gcc version

### DIFF
--- a/src/hdtv/rootext/mfile-root/mfile/include/mfile.h
+++ b/src/hdtv/rootext/mfile-root/mfile/include/mfile.h
@@ -121,6 +121,7 @@ typedef struct minfo {
 
 typedef struct accessmethod *amp;
 
+typedef struct matfile MFILE;
 typedef struct matfile {
   amp ap;
   char *name;
@@ -132,14 +133,15 @@ typedef struct matfile {
   uint32_t levels;
   uint32_t lines;
   uint32_t columns;
-  int32_t (*mflushf)();
-  int32_t (*muninitf)();
-  int32_t (*mgeti4f)();
-  int32_t (*mgetf4f)();
-  int32_t (*mgetf8f)();
-  int32_t (*mputi4f)();
-  int32_t (*mputf4f)();
-  int32_t (*mputf8f)();
+  int32_t (*mflushf)(MFILE *mat);
+  int32_t (*muninitf)(MFILE *mat);
+  int32_t (*mgeti4f)(MFILE *mat, void *b, int32_t v, int32_t l, int32_t c, int32_t);
+  int32_t (*mgetf4f)(MFILE *mat, void *b, int32_t v, int32_t l, int32_t c, int32_t n);
+  int32_t (*mgetf8f)(MFILE *mat, void *b, int32_t v, int32_t l, int32_t c, int32_t n);
+  int32_t (*mputi4f)(MFILE *mat, void *b, int32_t v, int32_t l, int32_t c, int32_t n);
+  int32_t (*mputf4f)(MFILE *mat, void *b, int32_t v, int32_t l, int32_t c, int32_t n);
+  int32_t (*mputf8f)(MFILE *mat, void *b, int32_t v, int32_t l, int32_t c, int32_t n);
+
   union {
     void *p;
     int32_t i;
@@ -161,14 +163,14 @@ int32_t msetfmt(MFILE *mat, const char *format);
 char *mgetfmt(MFILE *mat, char *format);
 
 /* lev: [0..(levels-1)], lin: [0..(lines-1)], col: [0..(columns-1)] */
-int32_t mgetint(MFILE *mat, int32_t buf[], int32_t lev, int32_t lin, int32_t col, int32_t num);
-int32_t mputint(MFILE *mat, int32_t buf[], int32_t lev, int32_t lin, int32_t col, int32_t num);
+int32_t mgetint(MFILE *mat, void *buf, int32_t lev, int32_t lin, int32_t col, int32_t num);
+int32_t mputint(MFILE *mat, void *buf, int32_t lev, int32_t lin, int32_t col, int32_t num);
 
-int32_t mgetflt(MFILE *mat, float buf[], int32_t lev, int32_t lin, int32_t col, int32_t num);
-int32_t mputflt(MFILE *mat, float buf[], int32_t lev, int32_t lin, int32_t col, int32_t num);
+int32_t mgetflt(MFILE *mat, void *buf, int32_t lev, int32_t lin, int32_t col, int32_t num);
+int32_t mputflt(MFILE *mat, void *buf, int32_t lev, int32_t lin, int32_t col, int32_t num);
 
-int32_t mgetdbl(MFILE *mat, double buf[], int32_t lev, int32_t lin, int32_t col, int32_t num);
-int32_t mputdbl(MFILE *mat, double buf[], int32_t lev, int32_t lin, int32_t col, int32_t num);
+int32_t mgetdbl(MFILE *mat, void *buf, int32_t lev, int32_t lin, int32_t col, int32_t num);
+int32_t mputdbl(MFILE *mat, void *buf, int32_t lev, int32_t lin, int32_t col, int32_t num);
 
 #define mget(mat, buf, lev, lin, col, num) mgetint(mat, buf, lev, lin, col, num)
 #define mput(mat, buf, lev, lin, col, num) mputint(mat, buf, lev, lin, col, num)

--- a/src/hdtv/rootext/mfile-root/mfile/src/callindir.c
+++ b/src/hdtv/rootext/mfile-root/mfile/src/callindir.c
@@ -36,9 +36,9 @@
   (mat && buffer && (uint32_t)level < mat->levels && (uint32_t)line < mat->lines && (uint32_t)col < mat->columns &&    \
    (uint32_t)num <= mat->columns && (uint32_t)(col + num) <= mat->columns)
 
-int32_t mgetint(MFILE *mat, int32_t *buffer, int32_t level, int32_t line, int32_t col, int32_t num) {
+int32_t mgetint(MFILE *mat, void *buffer, int32_t level, int32_t line, int32_t col, int32_t num) {
 
-  int32_t (*f)();
+  int32_t (*f)(MFILE *mat, void *buffer, int32_t level, int32_t line, int32_t col, int32_t num);
 
   /* sanity checks */
   if (paramok(mat, buffer, level, line, col, num)) {
@@ -54,9 +54,9 @@ int32_t mgetint(MFILE *mat, int32_t *buffer, int32_t level, int32_t line, int32_
   return -1;
 }
 
-int32_t mputint(MFILE *mat, int32_t *buffer, int32_t level, int32_t line, int32_t col, int32_t num) {
+int32_t mputint(MFILE *mat, void *buffer, int32_t level, int32_t line, int32_t col, int32_t num) {
 
-  int32_t (*f)();
+  int32_t (*f)(MFILE *mat, void *buffer, int32_t level, int32_t line, int32_t col, int32_t num);
 
   /* sanity checks */
   if (paramok(mat, buffer, level, line, col, num)) {
@@ -78,9 +78,9 @@ int32_t mputint(MFILE *mat, int32_t *buffer, int32_t level, int32_t line, int32_
 
 /*------------------------------------------------------------------------*/
 
-int32_t mgetflt(MFILE *mat, float *buffer, int32_t level, int32_t line, int32_t col, int32_t num) {
+int32_t mgetflt(MFILE *mat, void *buffer, int32_t level, int32_t line, int32_t col, int32_t num) {
 
-  int32_t (*f)();
+  int32_t (*f)(MFILE *mat, void *buffer, int32_t level, int32_t line, int32_t col, int32_t num);
 
   /* sanity checks */
   if (paramok(mat, buffer, level, line, col, num)) {
@@ -96,9 +96,9 @@ int32_t mgetflt(MFILE *mat, float *buffer, int32_t level, int32_t line, int32_t 
   return -1;
 }
 
-int32_t mputflt(MFILE *mat, float *buffer, int32_t level, int32_t line, int32_t col, int32_t num) {
+int32_t mputflt(MFILE *mat, void *buffer, int32_t level, int32_t line, int32_t col, int32_t num) {
 
-  int32_t (*f)();
+  int32_t (*f)(MFILE *mat, void *buffer, int32_t level, int32_t line, int32_t col, int32_t num);
 
   /* sanity checks */
   if (paramok(mat, buffer, level, line, col, num)) {
@@ -120,9 +120,9 @@ int32_t mputflt(MFILE *mat, float *buffer, int32_t level, int32_t line, int32_t 
 
 /*------------------------------------------------------------------------*/
 
-int32_t mgetdbl(MFILE *mat, double *buffer, int32_t level, int32_t line, int32_t col, int32_t num) {
+int32_t mgetdbl(MFILE *mat, void *buffer, int32_t level, int32_t line, int32_t col, int32_t num) {
 
-  int32_t (*f)();
+  int32_t (*f)(MFILE *mat, void *buffer, int32_t level, int32_t line, int32_t col, int32_t num);
 
   /* sanity checks */
   if (paramok(mat, buffer, level, line, col, num)) {
@@ -138,9 +138,9 @@ int32_t mgetdbl(MFILE *mat, double *buffer, int32_t level, int32_t line, int32_t
   return -1;
 }
 
-int32_t mputdbl(MFILE *mat, double *buffer, int32_t level, int32_t line, int32_t col, int32_t num) {
+int32_t mputdbl(MFILE *mat, void *buffer, int32_t level, int32_t line, int32_t col, int32_t num) {
 
-  int32_t (*f)();
+  int32_t (*f)(MFILE *mat, void *buffer, int32_t level, int32_t line, int32_t col, int32_t num);
 
   /* sanity checks */
   if (paramok(mat, buffer, level, line, col, num)) {

--- a/src/hdtv/rootext/mfile-root/mfile/src/callindir.h
+++ b/src/hdtv/rootext/mfile-root/mfile/src/callindir.h
@@ -30,9 +30,9 @@
 #include "mfile.h"
 #include <stdint.h>
 
-extern int32_t mgetint(MFILE *mat, int32_t *buffer, int32_t level, int32_t line, int32_t col, int32_t num);
-extern int32_t mputint(MFILE *mat, int32_t *buffer, int32_t level, int32_t line, int32_t col, int32_t num);
-extern int32_t mgetflt(MFILE *mat, float *buffer, int32_t level, int32_t line, int32_t col, int32_t num);
-extern int32_t mputflt(MFILE *mat, float *buffer, int32_t level, int32_t line, int32_t col, int32_t num);
-extern int32_t mgetdbl(MFILE *mat, double *buffer, int32_t level, int32_t line, int32_t col, int32_t num);
-extern int32_t mputdbl(MFILE *mat, double *buffer, int32_t level, int32_t line, int32_t col, int32_t num);
+extern int32_t mgetint(MFILE *mat, void *buffer, int32_t level, int32_t line, int32_t col, int32_t num);
+extern int32_t mputint(MFILE *mat, void *buffer, int32_t level, int32_t line, int32_t col, int32_t num);
+extern int32_t mgetflt(MFILE *mat, void *buffer, int32_t level, int32_t line, int32_t col, int32_t num);
+extern int32_t mputflt(MFILE *mat, void *buffer, int32_t level, int32_t line, int32_t col, int32_t num);
+extern int32_t mgetdbl(MFILE *mat, void *buffer, int32_t level, int32_t line, int32_t col, int32_t num);
+extern int32_t mputdbl(MFILE *mat, void *buffer, int32_t level, int32_t line, int32_t col, int32_t num);

--- a/src/hdtv/rootext/mfile-root/mfile/src/converters.c
+++ b/src/hdtv/rootext/mfile-root/mfile/src/converters.c
@@ -42,21 +42,21 @@ static int32_t conv_dbl_to_flt(float *dst, const double *src, int32_t num);
 static int32_t conv_flt_to_int(int32_t *dst, const float *src, int32_t num);
 static int32_t conv_dbl_to_int(int32_t *dst, const double *src, int32_t num);
 
-static int32_t mgetint_via_flt(MFILE *mat, int32_t *b, int32_t v, int32_t l, int32_t c, int32_t n);
+static int32_t mgetint_via_flt(MFILE *mat, void *b, int32_t v, int32_t l, int32_t c, int32_t n);
 
-static int32_t mgetint_via_dbl(MFILE *mat, int32_t *b, int32_t v, int32_t l, int32_t c, int32_t n);
+static int32_t mgetint_via_dbl(MFILE *mat, void *b, int32_t v, int32_t l, int32_t c, int32_t n);
 
-static int32_t mgetflt_via_int(MFILE *mat, float *b, int32_t v, int32_t l, int32_t c, int32_t n);
-static int32_t mgetflt_via_dbl(MFILE *mat, float *b, int32_t v, int32_t l, int32_t c, int32_t n);
-static int32_t mgetdbl_via_int(MFILE *mat, double *b, int32_t v, int32_t l, int32_t c, int32_t n);
-static int32_t mgetdbl_via_flt(MFILE *mat, double *b, int32_t v, int32_t l, int32_t c, int32_t n);
+static int32_t mgetflt_via_int(MFILE *mat, void *b, int32_t v, int32_t l, int32_t c, int32_t n);
+static int32_t mgetflt_via_dbl(MFILE *mat, void *b, int32_t v, int32_t l, int32_t c, int32_t n);
+static int32_t mgetdbl_via_int(MFILE *mat, void *b, int32_t v, int32_t l, int32_t c, int32_t n);
+static int32_t mgetdbl_via_flt(MFILE *mat, void *b, int32_t v, int32_t l, int32_t c, int32_t n);
 
-static int32_t mputint_via_flt(MFILE *mat, int32_t *b, int32_t v, int32_t l, int32_t c, int32_t n);
-static int32_t mputint_via_dbl(MFILE *mat, int32_t *b, int32_t v, int32_t l, int32_t c, int32_t n);
-static int32_t mputflt_via_int(MFILE *mat, float *b, int32_t v, int32_t l, int32_t c, int32_t n);
-static int32_t mputflt_via_dbl(MFILE *mat, float *b, int32_t v, int32_t l, int32_t c, int32_t n);
-static int32_t mputdbl_via_int(MFILE *mat, double *b, int32_t v, int32_t l, int32_t c, int32_t n);
-static int32_t mputdbl_via_flt(MFILE *mat, double *b, int32_t v, int32_t l, int32_t c, int32_t n);
+static int32_t mputint_via_flt(MFILE *mat, void *b, int32_t v, int32_t l, int32_t c, int32_t n);
+static int32_t mputint_via_dbl(MFILE *mat, void *b, int32_t v, int32_t l, int32_t c, int32_t n);
+static int32_t mputflt_via_int(MFILE *mat, void *b, int32_t v, int32_t l, int32_t c, int32_t n);
+static int32_t mputflt_via_dbl(MFILE *mat, void *b, int32_t v, int32_t l, int32_t c, int32_t n);
+static int32_t mputdbl_via_int(MFILE *mat, void *b, int32_t v, int32_t l, int32_t c, int32_t n);
+static int32_t mputdbl_via_flt(MFILE *mat, void *b, int32_t v, int32_t l, int32_t c, int32_t n);
 
 /*------------------------------------------------------------------------*/
 
@@ -134,124 +134,124 @@ static void checkconvbuffer(uint32_t size) {
   }
 }
 
-static int32_t mgetint_via_flt(MFILE *mat, int32_t *b, int32_t v, int32_t l, int32_t c, int32_t n) {
+static int32_t mgetint_via_flt(MFILE *mat, void *b, int32_t v, int32_t l, int32_t c, int32_t n) {
 
   int32_t num;
 
   checkconvbuffer(n * sizeof(float));
   num = mgetflt(mat, (float *)mgetconvbuf, v, l, c, n);
 
-  return conv_flt_to_int(b, (float *)mgetconvbuf, num);
+  return conv_flt_to_int((int32_t *)b, (float *)mgetconvbuf, num);
 }
 
-static int32_t mgetint_via_dbl(MFILE *mat, int32_t *b, int32_t v, int32_t l, int32_t c, int32_t n) {
+static int32_t mgetint_via_dbl(MFILE *mat, void *b, int32_t v, int32_t l, int32_t c, int32_t n) {
 
   int32_t num;
 
   checkconvbuffer(n * sizeof(double));
   num = mgetdbl(mat, (double *)mgetconvbuf, v, l, c, n);
 
-  return conv_dbl_to_int(b, (double *)mgetconvbuf, num);
+  return conv_dbl_to_int((int32_t *)b, (double *)mgetconvbuf, num);
 }
 
-static int32_t mgetflt_via_int(MFILE *mat, float *b, int32_t v, int32_t l, int32_t c, int32_t n) {
+static int32_t mgetflt_via_int(MFILE *mat, void *b, int32_t v, int32_t l, int32_t c, int32_t n) {
 
   int32_t num;
 
   checkconvbuffer(n * sizeof(int));
   num = mgetint(mat, (int32_t *)mgetconvbuf, v, l, c, n);
 
-  return conv_int_to_flt(b, (int32_t *)mgetconvbuf, num);
+  return conv_int_to_flt((float *)b, (int32_t *)mgetconvbuf, num);
 }
 
-static int32_t mgetflt_via_dbl(MFILE *mat, float *b, int32_t v, int32_t l, int32_t c, int32_t n) {
+static int32_t mgetflt_via_dbl(MFILE *mat, void *b, int32_t v, int32_t l, int32_t c, int32_t n) {
 
   int32_t num;
 
   checkconvbuffer(n * sizeof(double));
   num = mgetdbl(mat, (double *)mgetconvbuf, v, l, c, n);
 
-  return conv_dbl_to_flt(b, (double *)mgetconvbuf, num);
+  return conv_dbl_to_flt((float *)b, (double *)mgetconvbuf, num);
 }
 
-static int32_t mgetdbl_via_int(MFILE *mat, double *b, int32_t v, int32_t l, int32_t c, int32_t n) {
+static int32_t mgetdbl_via_int(MFILE *mat, void *b, int32_t v, int32_t l, int32_t c, int32_t n) {
 
   int32_t num;
 
   checkconvbuffer(n * sizeof(int));
   num = mgetint(mat, (int32_t *)mgetconvbuf, v, l, c, n);
 
-  return conv_int_to_dbl(b, (int32_t *)mgetconvbuf, num);
+  return conv_int_to_dbl((double *)b, (int32_t *)mgetconvbuf, num);
 }
 
-static int32_t mgetdbl_via_flt(MFILE *mat, double *b, int32_t v, int32_t l, int32_t c, int32_t n) {
+static int32_t mgetdbl_via_flt(MFILE *mat, void *b, int32_t v, int32_t l, int32_t c, int32_t n) {
 
   int32_t num;
 
   checkconvbuffer(n * sizeof(float));
   num = mgetflt(mat, (float *)mgetconvbuf, v, l, c, n);
 
-  return conv_flt_to_dbl(b, (float *)mgetconvbuf, num);
+  return conv_flt_to_dbl((double *)b, (float *)mgetconvbuf, num);
 }
 
 /*------------------------------------------------------------------------*/
 
-static int32_t mputint_via_flt(MFILE *mat, int32_t *b, int32_t v, int32_t l, int32_t c, int32_t n) {
+static int32_t mputint_via_flt(MFILE *mat, void *b, int32_t v, int32_t l, int32_t c, int32_t n) {
 
   int32_t num;
 
   checkconvbuffer(n * sizeof(float));
-  num = conv_int_to_flt((float *)mgetconvbuf, b, n);
+  num = conv_int_to_flt((float *)mgetconvbuf, (int32_t *)b, n);
 
   return mputflt(mat, (float *)mgetconvbuf, v, l, c, num);
 }
 
-static int32_t mputint_via_dbl(MFILE *mat, int32_t *b, int32_t v, int32_t l, int32_t c, int32_t n) {
+static int32_t mputint_via_dbl(MFILE *mat, void *b, int32_t v, int32_t l, int32_t c, int32_t n) {
 
   int32_t num;
 
   checkconvbuffer(n * sizeof(double));
-  num = conv_int_to_dbl((double *)mgetconvbuf, b, n);
+  num = conv_int_to_dbl((double *)mgetconvbuf, (int32_t *)b, n);
 
   return mputdbl(mat, (double *)mgetconvbuf, v, l, c, num);
 }
 
-static int32_t mputflt_via_int(MFILE *mat, float *b, int32_t v, int32_t l, int32_t c, int32_t n) {
+static int32_t mputflt_via_int(MFILE *mat, void *b, int32_t v, int32_t l, int32_t c, int32_t n) {
 
   int32_t num;
 
   checkconvbuffer(n * sizeof(int));
-  num = conv_flt_to_int((int32_t *)mgetconvbuf, b, n);
+  num = conv_flt_to_int((int32_t *)mgetconvbuf, (float *)b, n);
 
   return mputint(mat, (int32_t *)mgetconvbuf, v, l, c, num);
 }
 
-static int32_t mputflt_via_dbl(MFILE *mat, float *b, int32_t v, int32_t l, int32_t c, int32_t n) {
+static int32_t mputflt_via_dbl(MFILE *mat, void *b, int32_t v, int32_t l, int32_t c, int32_t n) {
 
   int32_t num;
 
   checkconvbuffer(n * sizeof(double));
-  num = conv_flt_to_dbl((double *)mgetconvbuf, b, n);
+  num = conv_flt_to_dbl((double *)mgetconvbuf, (float *)b, n);
 
   return mputdbl(mat, (double *)mgetconvbuf, v, l, c, num);
 }
 
-static int32_t mputdbl_via_int(MFILE *mat, double *b, int32_t v, int32_t l, int32_t c, int32_t n) {
+static int32_t mputdbl_via_int(MFILE *mat, void *b, int32_t v, int32_t l, int32_t c, int32_t n) {
 
   int32_t num;
 
   checkconvbuffer(n * sizeof(int));
-  num = conv_dbl_to_int((int32_t *)mgetconvbuf, b, n);
+  num = conv_dbl_to_int((int32_t *)mgetconvbuf, (double *)b, n);
 
   return mputint(mat, (int32_t *)mgetconvbuf, v, l, c, num);
 }
 
-static int32_t mputdbl_via_flt(MFILE *mat, double *b, int32_t v, int32_t l, int32_t c, int32_t n) {
+static int32_t mputdbl_via_flt(MFILE *mat, void *b, int32_t v, int32_t l, int32_t c, int32_t n) {
 
   int32_t num;
 
   checkconvbuffer(n * sizeof(float));
-  num = conv_dbl_to_flt((float *)mgetconvbuf, b, n);
+  num = conv_dbl_to_flt((float *)mgetconvbuf, (double *)b, n);
 
   return mputflt(mat, (float *)mgetconvbuf, v, l, c, num);
 }

--- a/src/hdtv/rootext/mfile-root/mfile/src/lc_getput.h
+++ b/src/hdtv/rootext/mfile-root/mfile/src/lc_getput.h
@@ -31,6 +31,6 @@
 #include "mfile.h"
 #include <stdint.h>
 
-extern int32_t lc_get(MFILE *mat, int32_t *buffer, uint32_t level, uint32_t line, uint32_t col, uint32_t num);
-extern int32_t lc_put(MFILE *mat, int32_t *buffer, uint32_t level, uint32_t line, uint32_t col, uint32_t num);
+extern int32_t lc_get(MFILE *mat, void *buffer, int32_t level, int32_t line, int32_t col, int32_t num);
+extern int32_t lc_put(MFILE *mat, void *buffer, int32_t level, int32_t line, int32_t col, int32_t num);
 extern int32_t lc_flushcache(MFILE *mat);

--- a/src/hdtv/rootext/mfile-root/mfile/src/lc_minfo.h
+++ b/src/hdtv/rootext/mfile-root/mfile/src/lc_minfo.h
@@ -64,8 +64,8 @@ typedef struct {
   uint32_t comprlinelen;
   uint32_t poslentablepos;
   lc_poslen *poslentableptr;
-  int32_t (*comprf)();
-  int32_t (*uncomprf)();
+  int32_t (*comprf)(char *dest, int32_t *src, int32_t num);
+  int32_t (*uncomprf)(int32_t *dest, char *src, int32_t num);
 } lc_minfo;
 
 void lc_probe(MFILE *mat);

--- a/src/hdtv/rootext/mfile-root/mfile/src/mate_getput.c
+++ b/src/hdtv/rootext/mfile-root/mfile/src/mate_getput.c
@@ -29,14 +29,14 @@
 #include "mate_getput.h"
 #include "getputint.h"
 
-#define fpos(s) (((level * mat->lines + line) * mat->columns + col) * (s))
+#define fpos(s) ((((uint32_t)level * mat->lines + (uint32_t)line) * mat->columns + (uint32_t)col) * (s))
 
-int32_t mate_get(MFILE *mat, int32_t *buffer, uint32_t level, uint32_t line, uint32_t col, uint32_t num) {
-  int32_t nread = getle4(mat->ap, buffer, fpos(4) + 0x200, num);
+int32_t mate_get(MFILE *mat, void *buffer, int32_t level, int32_t line, int32_t col, int32_t num) {
+  int32_t nread = getle4(mat->ap, (int32_t *)buffer, fpos(4) + 0x200, (uint32_t)num);
   int32_t i;
 
   for (i = 0; i < nread; i++) {
-    buffer[i] &= 0xffffff;
+    ((int32_t *)buffer)[i] &= 0xffffff;
   }
   return nread;
 }

--- a/src/hdtv/rootext/mfile-root/mfile/src/mate_getput.h
+++ b/src/hdtv/rootext/mfile-root/mfile/src/mate_getput.h
@@ -30,4 +30,4 @@
 #include "mfile.h"
 #include <stdint.h>
 
-int32_t mate_get(MFILE *mat, int32_t *buffer, uint32_t level, uint32_t line, uint32_t col, uint32_t num);
+int32_t mate_get(MFILE *mat, void *buffer, int32_t level, int32_t line, int32_t col, int32_t num);

--- a/src/hdtv/rootext/mfile-root/mfile/src/oldmat_minfo.c
+++ b/src/hdtv/rootext/mfile-root/mfile/src/oldmat_minfo.c
@@ -46,9 +46,7 @@ static void guesslinescols(MFILE *mat, uint32_t size);
 
 char MAGIC_OLDMAT[] = "\nMatFmt: ";
 
-static void guessdatatype(mat, pos) MFILE *mat;
-uint32_t pos;
-{
+static void guessdatatype(MFILE *mat, uint32_t pos) {
   unsigned char buf[TESTBUFSIZE];
   int32_t nread;
   int32_t n1 = 0, n2 = 0, n3 = 0, n4 = 0;
@@ -71,7 +69,7 @@ uint32_t pos;
     n3 += buf[i + 2];
     n4 += buf[i + 3];
 /* consider floating point32_t number, if within 2^-3 to 2^20 */
-#define GETEXP(_n, _bits) (((_n)&0x7fff) >> (15 - (_bits)))
+#define GETEXP(_n, _bits) (((_n) & 0x7fff) >> (15 - (_bits)))
 #define MINEXP (-3)
 #define MAXEXP (20)
     tli = (buf[i + 3] << 8) + buf[i + 2];
@@ -130,9 +128,7 @@ uint32_t pos;
   }
 }
 
-static void guesslinescols(mat, size) MFILE *mat;
-uint32_t size;
-{
+static void guesslinescols(MFILE *mat, uint32_t size) {
   int32_t filetype = mat->filetype;
 
   if (filetype != MAT_INVALID) {
@@ -210,9 +206,7 @@ uint32_t size;
   }
 }
 
-static void checkformagic(mat, size) MFILE *mat;
-int32_t size;
-{
+static void checkformagic(MFILE *mat, int32_t size) {
   oldmat_header omh;
   uint32_t s = sizeof(omh);
   uint32_t l = strlen(MAGIC_OLDMAT);
@@ -225,8 +219,7 @@ int32_t size;
   msetfmt(mat, omh + l);
 }
 
-void oldmat_probe(mat) MFILE *mat;
-{
+void oldmat_probe(MFILE *mat) {
   uint32_t size = mat->ap->size;
 
   checkformagic(mat, size);
@@ -240,8 +233,7 @@ void oldmat_probe(mat) MFILE *mat;
   guesslinescols(mat, size);
 }
 
-void oldmat_init(mat) MFILE *mat;
-{
+void oldmat_init(MFILE *mat) {
   if (0 < mat->columns && mat->columns <= MAT_COLMAX) {
     int32_t filetype = mat->filetype;
     int32_t datatype = matproc_datatype(filetype);
@@ -284,9 +276,7 @@ void oldmat_init(mat) MFILE *mat;
   }
 }
 
-int32_t oldmat_uninit(mat)
-MFILE *mat;
-{
+int32_t oldmat_uninit(MFILE *mat) {
   if ((mat->status & MST_DIRTY) == 0)
     return 0;
 

--- a/src/hdtv/rootext/mfile-root/mfile/src/trixi_getput.c
+++ b/src/hdtv/rootext/mfile-root/mfile/src/trixi_getput.c
@@ -32,9 +32,9 @@
 #include "getputint.h"
 #include "trixi_getput.h"
 
-#define fpos(s) (((level * mat->lines + line) * mat->columns + col) * (s) + 512)
+#define fpos(s) ((((uint32_t)level * mat->lines + (uint32_t)line) * mat->columns + (uint32_t)col) * (s) + 512)
 
-int32_t trixi_get(MFILE *mat, int32_t *buffer, uint32_t level, uint32_t line, uint32_t col, uint32_t num) {
+int32_t trixi_get(MFILE *mat, void *buffer, int32_t level, int32_t line, int32_t col, int32_t num) {
 
-  return getle2(mat->ap, buffer, fpos(2), num);
+  return getle2(mat->ap, (int32_t *)buffer, fpos(2), (uint32_t)num);
 }

--- a/src/hdtv/rootext/mfile-root/mfile/src/trixi_getput.h
+++ b/src/hdtv/rootext/mfile-root/mfile/src/trixi_getput.h
@@ -30,4 +30,4 @@
 #include "mfile.h"
 #include <stdint.h>
 
-int32_t trixi_get(MFILE *mat, int32_t *buffer, uint32_t level, uint32_t line, uint32_t col, uint32_t num);
+int32_t trixi_get(MFILE *mat, void *buffer, int32_t level, int32_t line, int32_t col, int32_t num);

--- a/src/hdtv/rootext/mfile-root/mfile/src/txt_getput.c
+++ b/src/hdtv/rootext/mfile-root/mfile/src/txt_getput.c
@@ -34,27 +34,27 @@
 #include "txt_getput.h"
 #include "txt_minfo.h"
 
-int32_t txt_get(MFILE *mat, int32_t *buffer, uint32_t level, uint32_t line, uint32_t col, uint32_t num) {
+int32_t txt_get(MFILE *mat, void *buffer, int32_t level, int32_t line, int32_t col, int32_t num) {
 
   double *dblp = (double *)mat->specinfo.p;
 
   /*  if (dblp == NULL) return -1; */
 
-  int32_t idx = ((level * mat->lines) + line) * mat->columns + col;
+  int32_t idx = (((uint32_t)level * mat->lines) + (uint32_t)line) * mat->columns + (uint32_t)col;
 
-  memcpy(buffer, dblp + idx, num * sizeof(double));
+  memcpy((int32_t *)buffer, dblp + idx, (uint32_t)num * sizeof(double));
 
   return num;
 }
 
-int32_t txt_put(MFILE *mat, int32_t *buffer, uint32_t level, uint32_t line, uint32_t col, uint32_t num) {
+int32_t txt_put(MFILE *mat, void *buffer, int32_t level, int32_t line, int32_t col, int32_t num) {
   double *dblp = (double *)mat->specinfo.p;
 
   /*  if (dblp == NULL) return -1; */
 
-  int32_t idx = ((level * mat->lines) + line) * mat->columns + col;
+  int32_t idx = (((uint32_t)level * mat->lines) + (uint32_t)line) * mat->columns + (uint32_t)col;
 
-  memcpy(dblp + idx, buffer, num * sizeof(double));
+  memcpy(dblp + idx, (int32_t *)buffer, (uint32_t)num * sizeof(double));
 
   return num;
 }

--- a/src/hdtv/rootext/mfile-root/mfile/src/txt_getput.c
+++ b/src/hdtv/rootext/mfile-root/mfile/src/txt_getput.c
@@ -42,7 +42,7 @@ int32_t txt_get(MFILE *mat, void *buffer, int32_t level, int32_t line, int32_t c
 
   int32_t idx = (((uint32_t)level * mat->lines) + (uint32_t)line) * mat->columns + (uint32_t)col;
 
-  memcpy((int32_t *)buffer, dblp + idx, (uint32_t)num * sizeof(double));
+  memcpy((double *)buffer, dblp + idx, (uint32_t)num * sizeof(double));
 
   return num;
 }
@@ -54,7 +54,7 @@ int32_t txt_put(MFILE *mat, void *buffer, int32_t level, int32_t line, int32_t c
 
   int32_t idx = (((uint32_t)level * mat->lines) + (uint32_t)line) * mat->columns + (uint32_t)col;
 
-  memcpy(dblp + idx, (int32_t *)buffer, (uint32_t)num * sizeof(double));
+  memcpy(dblp + idx, (double *)buffer, (uint32_t)num * sizeof(double));
 
   return num;
 }

--- a/src/hdtv/rootext/mfile-root/mfile/src/txt_getput.h
+++ b/src/hdtv/rootext/mfile-root/mfile/src/txt_getput.h
@@ -31,6 +31,6 @@
 #include "mfile.h"
 #include <stdint.h>
 
-extern int32_t txt_get(MFILE *mat, int32_t *buffer, uint32_t level, uint32_t line, uint32_t col, uint32_t num);
-extern int32_t txt_put(MFILE *mat, int32_t *buffer, uint32_t level, uint32_t line, uint32_t col, uint32_t num);
+extern int32_t txt_get(MFILE *mat, void *buffer, int32_t level, int32_t line, int32_t col, int32_t num);
+extern int32_t txt_put(MFILE *mat, void *buffer, int32_t level, int32_t line, int32_t col, int32_t num);
 extern int32_t txt_flush(MFILE *mat);


### PR DESCRIPTION
This is a repost of #41 which I messed up with an erroneous force push. This PR includes the original changes and the suggestions made by @op3 in #41. The original text is below:

> I noticed hdtv would install correctly but failed to compile the binaries it builds against the user's ROOT and Python installations at first launch. After some digging I found that this was because of gcc-15 dropping support for some legacy syntax found in the mfile source code. After making the proposed updates hdtv compiles and appears to work. Definitely check this over beforehand as this was a quick-and-dirty patch by a not-so-experienced dev, I'm not sure what may break (if anything) as a result.
System Details:
ROOT 6.34.08
Python Python 3.13.3
GCC 15.1.1
OS: Arch Linux
Kernel: Linux 6.14.6-arch1-1



