### PR TITLE
Update mfile (CMakeLists.txt, GCC 15 / Clang21 compatibility)

### DIFF
--- a/src/hdtv/rootext/mfile-root/mfile/CMakeLists.txt
+++ b/src/hdtv/rootext/mfile-root/mfile/CMakeLists.txt
@@ -1,93 +1,77 @@
-cmake_minimum_required(VERSION 3.6 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.15)
+
 project(
   mfile
   VERSION 1.2
   LANGUAGES C)
 
-set(SOURCES
-    src/callindir.c
-    src/converters.c
-    src/disk_access.c
-    src/getputint.c
-    src/gf2_getput.c
-    src/gf2_minfo.c
-    src/lc_c1.c
-    src/lc_c2.c
-    src/lc_getput.c
-    src/lc_minfo.c
-    src/maccess.c
-    src/mate_getput.c
-    src/mate_minfo.c
-    src/mat_types.c
-    src/minfo.c
-    src/mopen.c
-    src/oldmat_getput.c
-    src/oldmat_minfo.c
-    src/shm_access.c
-    src/shm_getput.c
-    src/shm_minfo.c
-    src/specio.c
-    src/trixi_getput.c
-    src/trixi_minfo.c
-    src/txt_getput.c
-    src/txt_minfo.c)
+include(TestBigEndian)
+include(CheckFunctionExists)
+include(CheckIncludeFile)
 
-add_library(${PROJECT_NAME} SHARED ${SOURCES})
-add_library(hdtv::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
+add_library(
+  ${PROJECT_NAME} SHARED
+  src/callindir.c
+  src/converters.c
+  src/disk_access.c
+  src/getputint.c
+  src/gf2_getput.c
+  src/gf2_minfo.c
+  src/lc_c1.c
+  src/lc_c2.c
+  src/lc_getput.c
+  src/lc_minfo.c
+  src/maccess.c
+  src/mate_getput.c
+  src/mate_minfo.c
+  src/mat_types.c
+  src/minfo.c
+  src/mopen.c
+  src/oldmat_getput.c
+  src/oldmat_minfo.c
+  src/shm_access.c
+  src/shm_getput.c
+  src/shm_minfo.c
+  src/specio.c
+  src/trixi_getput.c
+  src/trixi_minfo.c
+  src/txt_getput.c
+  src/txt_minfo.c)
 
 set_target_properties(${PROJECT_NAME} PROPERTIES PUBLIC_HEADER include/mfile.h)
 
 target_include_directories(
   ${PROJECT_NAME}
-  PUBLIC $<INSTALL_INTERFACE:include> $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
-  PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
+  PUBLIC include
+  PRIVATE src)
 
-target_compile_features(${PROJECT_NAME} PRIVATE c_std_99)
+target_compile_features(${PROJECT_NAME} PRIVATE c_std_11)
 target_compile_options(${PROJECT_NAME} PRIVATE -ftrapv -Wall)
 
-# Check endian-ness
-include(TestBigEndian)
-test_big_endian(BIGENDIAN)
-if(NOT ${BIGENDIAN})
-  target_compile_definitions(${PROJECT_NAME} PRIVATE -DLOWENDIAN)
-endif(NOT ${BIGENDIAN})
+test_big_endian(IS_BIGENDIAN)
+if(NOT IS_BIGENDIAN)
+  target_compile_definitions(${PROJECT_NAME} PRIVATE LOWENDIAN)
+endif()
 
-# Check for snprintf
-include(CheckFunctionExists)
 check_function_exists(snprintf HAVE_SNPRINTF)
-if(${HAVE_SNPRINTF})
-  target_compile_definitions(${PROJECT_NAME} PRIVATE -DHAVE_SNPRINTF)
-endif(${HAVE_SNPRINTF})
+if(HAVE_SNPRINTF)
+  target_compile_definitions(${PROJECT_NAME} PRIVATE HAVE_SNPRINTF)
+endif()
 
-# Check for shared memory via sys/shm.h
-include(CheckIncludeFile)
-set(HAVE_SHM false)
 check_include_file("sys/shm.h" HAVE_SHM)
-if(NOT ${HAVE_SHM})
-  target_compile_definitions(${PROJECT_NAME} PRIVATE -DNO_SHM)
-endif(NOT ${HAVE_SHM})
+if(NOT HAVE_SHM)
+  target_compile_definitions(${PROJECT_NAME} PRIVATE NO_SHM)
+endif()
 
 install(
   TARGETS ${PROJECT_NAME}
-  EXPORT ${PROJECT_NAME}Config
   LIBRARY DESTINATION lib
-  ARCHIVE DESTINATION lib
   PUBLIC_HEADER DESTINATION include)
-install(
-  EXPORT ${PROJECT_NAME}Config
-  FILE ${PROJECT_NAME}Config.cmake
-  NAMESPACE hdtv::
-  DESTINATION share/${PROJECT_NAME}/cmake)
-export(TARGETS ${PROJECT_NAME} FILE ${PROJECT_NAME}Config.cmake)
 
-# Testing
 enable_testing()
-add_executable(check_mfile test/check_mfile.c)
-target_link_libraries(check_mfile hdtv::mfile)
-add_dependencies(check_mfile hdtv::mfile)
-add_test(run_check_mfile check_mfile)
-add_test(
-  run_check_spectra
-  md5sum
-  -c
-  ${CMAKE_CURRENT_SOURCE_DIR}/test/md5sums)
+
+add_executable(check_${PROJECT_NAME} test/check_mfile.c)
+target_link_libraries(check_${PROJECT_NAME} PRIVATE ${PROJECT_NAME})
+
+add_test(NAME run_check_${PROJECT_NAME} COMMAND check_${PROJECT_NAME})
+add_test(NAME run_check_spectra COMMAND md5sum -c ${CMAKE_CURRENT_SOURCE_DIR}/test/md5sums)

--- a/src/hdtv/rootext/mfile-root/mfile/include/mfile.h
+++ b/src/hdtv/rootext/mfile-root/mfile/include/mfile.h
@@ -121,7 +121,9 @@ typedef struct minfo {
 
 typedef struct accessmethod *amp;
 
-typedef struct matfile {
+typedef struct matfile MFILE;
+
+struct matfile {
   amp ap;
   char *name;
   char *comment;
@@ -132,19 +134,19 @@ typedef struct matfile {
   uint32_t levels;
   uint32_t lines;
   uint32_t columns;
-  int32_t (*mflushf)();
-  int32_t (*muninitf)();
-  int32_t (*mgeti4f)();
-  int32_t (*mgetf4f)();
-  int32_t (*mgetf8f)();
-  int32_t (*mputi4f)();
-  int32_t (*mputf4f)();
-  int32_t (*mputf8f)();
+  int32_t (*mflushf)(MFILE *mat);
+  int32_t (*muninitf)(MFILE *mat);
+  int32_t (*mgeti4f)(MFILE *mat, int32_t *buf, int32_t level, int32_t line, int32_t col, int32_t num);
+  int32_t (*mgetf4f)(MFILE *mat, float *buf, int32_t level, int32_t line, int32_t col, int32_t num);
+  int32_t (*mgetf8f)(MFILE *mat, double *buf, int32_t level, int32_t line, int32_t col, int32_t num);
+  int32_t (*mputi4f)(MFILE *mat, int32_t *buf, int32_t level, int32_t line, int32_t col, int32_t num);
+  int32_t (*mputf4f)(MFILE *mat, float *buf, int32_t level, int32_t line, int32_t col, int32_t num);
+  int32_t (*mputf8f)(MFILE *mat, double *buf, int32_t level, int32_t line, int32_t col, int32_t num);
   union {
     void *p;
     int32_t i;
   } specinfo;
-} MFILE;
+};
 
 MFILE *mopen(const char *name, const char *mode);
 int32_t mclose(MFILE *mat);
@@ -161,14 +163,14 @@ int32_t msetfmt(MFILE *mat, const char *format);
 char *mgetfmt(MFILE *mat, char *format);
 
 /* lev: [0..(levels-1)], lin: [0..(lines-1)], col: [0..(columns-1)] */
-int32_t mgetint(MFILE *mat, int32_t buf[], int32_t lev, int32_t lin, int32_t col, int32_t num);
-int32_t mputint(MFILE *mat, int32_t buf[], int32_t lev, int32_t lin, int32_t col, int32_t num);
+int32_t mgetint(MFILE *mat, int32_t *buf, int32_t lev, int32_t lin, int32_t col, int32_t num);
+int32_t mputint(MFILE *mat, int32_t *buf, int32_t lev, int32_t lin, int32_t col, int32_t num);
 
-int32_t mgetflt(MFILE *mat, float buf[], int32_t lev, int32_t lin, int32_t col, int32_t num);
-int32_t mputflt(MFILE *mat, float buf[], int32_t lev, int32_t lin, int32_t col, int32_t num);
+int32_t mgetflt(MFILE *mat, float *buf, int32_t lev, int32_t lin, int32_t col, int32_t num);
+int32_t mputflt(MFILE *mat, float *buf, int32_t lev, int32_t lin, int32_t col, int32_t num);
 
-int32_t mgetdbl(MFILE *mat, double buf[], int32_t lev, int32_t lin, int32_t col, int32_t num);
-int32_t mputdbl(MFILE *mat, double buf[], int32_t lev, int32_t lin, int32_t col, int32_t num);
+int32_t mgetdbl(MFILE *mat, double *buf, int32_t lev, int32_t lin, int32_t col, int32_t num);
+int32_t mputdbl(MFILE *mat, double *buf, int32_t lev, int32_t lin, int32_t col, int32_t num);
 
 #define mget(mat, buf, lev, lin, col, num) mgetint(mat, buf, lev, lin, col, num)
 #define mput(mat, buf, lev, lin, col, num) mputint(mat, buf, lev, lin, col, num)

--- a/src/hdtv/rootext/mfile-root/mfile/src/callindir.c
+++ b/src/hdtv/rootext/mfile-root/mfile/src/callindir.c
@@ -37,41 +37,38 @@
    (uint32_t)num <= mat->columns && (uint32_t)(col + num) <= mat->columns)
 
 int32_t mgetint(MFILE *mat, int32_t *buffer, int32_t level, int32_t line, int32_t col, int32_t num) {
-
-  int32_t (*f)();
-
   /* sanity checks */
-  if (paramok(mat, buffer, level, line, col, num)) {
+  if (!paramok(mat, buffer, level, line, col, num))
+    return -1;
 
-    if ((f = mat->mgeti4f))
-      return f(mat, buffer, level, line, col, num);
-    matproc_init(mat);
-    installconverters(mat);
-    if ((f = mat->mgeti4f))
-      return f(mat, buffer, level, line, col, num);
-  }
+  if (mat->mgeti4f)
+    return mat->mgeti4f(mat, buffer, level, line, col, num);
+
+  matproc_init(mat);
+  installconverters(mat);
+  if (mat->mgeti4f)
+    return mat->mgeti4f(mat, buffer, level, line, col, num);
 
   return -1;
 }
 
 int32_t mputint(MFILE *mat, int32_t *buffer, int32_t level, int32_t line, int32_t col, int32_t num) {
-
-  int32_t (*f)();
-
   /* sanity checks */
-  if (paramok(mat, buffer, level, line, col, num)) {
+  if (!paramok(mat, buffer, level, line, col, num))
+    return -1;
 
-    mat->status |= (MST_DIRTY | MST_DIMSFIXED);
+  mat->status |= (MST_DIRTY | MST_DIMSFIXED);
 
-    if ((f = mat->mputi4f))
-      return f(mat, buffer, level, line, col, num);
-    if (mat->filetype == MAT_UNKNOWN)
-      mat->filetype = MAT_STD_INT;
-    matproc_init(mat);
-    installconverters(mat);
-    if ((f = mat->mputi4f))
-      return f(mat, buffer, level, line, col, num);
-  }
+  if (mat->mputi4f)
+    return mat->mputi4f(mat, buffer, level, line, col, num);
+
+  if (mat->filetype == MAT_UNKNOWN)
+    mat->filetype = MAT_STD_INT;
+
+  matproc_init(mat);
+  installconverters(mat);
+  if (mat->mputi4f)
+    return mat->mputi4f(mat, buffer, level, line, col, num);
 
   return -1;
 }
@@ -79,41 +76,38 @@ int32_t mputint(MFILE *mat, int32_t *buffer, int32_t level, int32_t line, int32_
 /*------------------------------------------------------------------------*/
 
 int32_t mgetflt(MFILE *mat, float *buffer, int32_t level, int32_t line, int32_t col, int32_t num) {
-
-  int32_t (*f)();
-
   /* sanity checks */
-  if (paramok(mat, buffer, level, line, col, num)) {
+  if (!paramok(mat, buffer, level, line, col, num))
+    return -1;
 
-    if ((f = mat->mgetf4f))
-      return f(mat, buffer, level, line, col, num);
-    matproc_init(mat);
-    installconverters(mat);
-    if ((f = mat->mgetf4f))
-      return f(mat, buffer, level, line, col, num);
-  }
+  if (mat->mgetf4f)
+    return mat->mgetf4f(mat, buffer, level, line, col, num);
+
+  matproc_init(mat);
+  installconverters(mat);
+  if (mat->mgetf4f)
+    return mat->mgetf4f(mat, buffer, level, line, col, num);
 
   return -1;
 }
 
 int32_t mputflt(MFILE *mat, float *buffer, int32_t level, int32_t line, int32_t col, int32_t num) {
-
-  int32_t (*f)();
-
   /* sanity checks */
-  if (paramok(mat, buffer, level, line, col, num)) {
+  if (!paramok(mat, buffer, level, line, col, num))
+    return -1;
 
-    mat->status |= (MST_DIRTY | MST_DIMSFIXED);
+  mat->status |= (MST_DIRTY | MST_DIMSFIXED);
 
-    if ((f = mat->mputf4f))
-      return f(mat, buffer, level, line, col, num);
-    if (mat->filetype == MAT_UNKNOWN)
-      mat->filetype = MAT_STD_FLT;
-    matproc_init(mat);
-    installconverters(mat);
-    if ((f = mat->mputf4f))
-      return f(mat, buffer, level, line, col, num);
-  }
+  if (mat->mputf4f)
+    return mat->mputf4f(mat, buffer, level, line, col, num);
+
+  if (mat->filetype == MAT_UNKNOWN)
+    mat->filetype = MAT_STD_FLT;
+
+  matproc_init(mat);
+  installconverters(mat);
+  if (mat->mputf4f)
+    return mat->mputf4f(mat, buffer, level, line, col, num);
 
   return -1;
 }
@@ -121,41 +115,38 @@ int32_t mputflt(MFILE *mat, float *buffer, int32_t level, int32_t line, int32_t 
 /*------------------------------------------------------------------------*/
 
 int32_t mgetdbl(MFILE *mat, double *buffer, int32_t level, int32_t line, int32_t col, int32_t num) {
-
-  int32_t (*f)();
-
   /* sanity checks */
-  if (paramok(mat, buffer, level, line, col, num)) {
+  if (!paramok(mat, buffer, level, line, col, num))
+    return -1;
 
-    if ((f = mat->mgetf8f))
-      return f(mat, buffer, level, line, col, num);
-    matproc_init(mat);
-    installconverters(mat);
-    if ((f = mat->mgetf8f))
-      return f(mat, buffer, level, line, col, num);
-  }
+  if (mat->mgetf8f)
+    return mat->mgetf8f(mat, buffer, level, line, col, num);
+
+  matproc_init(mat);
+  installconverters(mat);
+  if (mat->mgetf8f)
+    return mat->mgetf8f(mat, buffer, level, line, col, num);
 
   return -1;
 }
 
 int32_t mputdbl(MFILE *mat, double *buffer, int32_t level, int32_t line, int32_t col, int32_t num) {
-
-  int32_t (*f)();
-
   /* sanity checks */
-  if (paramok(mat, buffer, level, line, col, num)) {
+  if (!paramok(mat, buffer, level, line, col, num))
+    return -1;
 
-    mat->status |= (MST_DIRTY | MST_DIMSFIXED);
+  mat->status |= (MST_DIRTY | MST_DIMSFIXED);
 
-    if ((f = mat->mputf8f))
-      return f(mat, buffer, level, line, col, num);
-    if (mat->filetype == MAT_UNKNOWN)
-      mat->filetype = MAT_STD_DBL;
-    matproc_init(mat);
-    installconverters(mat);
-    if ((f = mat->mputf8f))
-      return f(mat, buffer, level, line, col, num);
-  }
+  if (mat->mputf8f)
+    return mat->mputf8f(mat, buffer, level, line, col, num);
+
+  if (mat->filetype == MAT_UNKNOWN)
+    mat->filetype = MAT_STD_DBL;
+
+  matproc_init(mat);
+  installconverters(mat);
+  if (mat->mputf8f)
+    return mat->mputf8f(mat, buffer, level, line, col, num);
 
   return -1;
 }

--- a/src/hdtv/rootext/mfile-root/mfile/src/gf2_minfo.c
+++ b/src/hdtv/rootext/mfile-root/mfile/src/gf2_minfo.c
@@ -91,8 +91,11 @@ void gf2_init(MFILE *mat) {
     mat->specinfo.i = elemsize;
     mat->version = GF2_STD_VERSION;
 
-    mat->mgetf4f = getfLocal;
-    mat->mputf4f = putfLocal;
+    // TODO:
+    // Casting function pointers with different argument types is theoretically undefined behavior (C11 6.3.2.3p1/p8).
+    // In this case, only pointer arguments are casted. Current compilers handle this just fine.
+    mat->mgetf4f = (mgetf4f *)getfLocal;
+    mat->mputf4f = (mputf4f *)putfLocal;
     mat->muninitf = gf2_uninit;
   }
 }

--- a/src/hdtv/rootext/mfile-root/mfile/src/lc_getput.c
+++ b/src/hdtv/rootext/mfile-root/mfile/src/lc_getput.c
@@ -144,7 +144,7 @@ static void trycacheline(MFILE *mat, uint32_t line) {
   }
 }
 
-int32_t lc_get(MFILE *mat, int32_t *buffer, uint32_t level, uint32_t line, uint32_t col, uint32_t num) {
+int32_t lc_get(MFILE *mat, int32_t *buffer, int32_t level, int32_t line, int32_t col, int32_t num) {
 
   lc_minfo *lci = (lc_minfo *)mat->specinfo.p;
 
@@ -165,7 +165,7 @@ int32_t lc_get(MFILE *mat, int32_t *buffer, uint32_t level, uint32_t line, uint3
   return -1;
 }
 
-int32_t lc_put(MFILE *mat, int32_t *buffer, uint32_t level, uint32_t line, uint32_t col, uint32_t num) {
+int32_t lc_put(MFILE *mat, int32_t *buffer, int32_t level, int32_t line, int32_t col, int32_t num) {
 
   lc_minfo *lci = (lc_minfo *)mat->specinfo.p;
 

--- a/src/hdtv/rootext/mfile-root/mfile/src/lc_getput.h
+++ b/src/hdtv/rootext/mfile-root/mfile/src/lc_getput.h
@@ -31,6 +31,6 @@
 #include "mfile.h"
 #include <stdint.h>
 
-extern int32_t lc_get(MFILE *mat, int32_t *buffer, uint32_t level, uint32_t line, uint32_t col, uint32_t num);
-extern int32_t lc_put(MFILE *mat, int32_t *buffer, uint32_t level, uint32_t line, uint32_t col, uint32_t num);
+extern int32_t lc_get(MFILE *mat, int32_t *buffer, int32_t level, int32_t line, int32_t col, int32_t num);
+extern int32_t lc_put(MFILE *mat, int32_t *buffer, int32_t level, int32_t line, int32_t col, int32_t num);
 extern int32_t lc_flushcache(MFILE *mat);

--- a/src/hdtv/rootext/mfile-root/mfile/src/lc_minfo.h
+++ b/src/hdtv/rootext/mfile-root/mfile/src/lc_minfo.h
@@ -64,8 +64,8 @@ typedef struct {
   uint32_t comprlinelen;
   uint32_t poslentablepos;
   lc_poslen *poslentableptr;
-  int32_t (*comprf)();
-  int32_t (*uncomprf)();
+  int32_t (*comprf)(char *dest, int32_t *src, int32_t num);
+  int32_t (*uncomprf)(int32_t *dst, char *src, int32_t num);
 } lc_minfo;
 
 void lc_probe(MFILE *mat);

--- a/src/hdtv/rootext/mfile-root/mfile/src/mat_types.h
+++ b/src/hdtv/rootext/mfile-root/mfile/src/mat_types.h
@@ -35,6 +35,15 @@ typedef void minitf(MFILE *mat);
 typedef int32_t mgetf(MFILE *mat, void *buf, int32_t v, int32_t l, int32_t c, int32_t n);
 typedef int32_t mputf(MFILE *mat, void *buf, int32_t v, int32_t l, int32_t c, int32_t n);
 
+typedef int32_t mgeti4f(MFILE *mat, int32_t *buf, int32_t v, int32_t l, int32_t c, int32_t n);
+typedef int32_t mputi4f(MFILE *mat, int32_t *buf, int32_t v, int32_t l, int32_t c, int32_t n);
+
+typedef int32_t mgetf4f(MFILE *mat, float *buf, int32_t v, int32_t l, int32_t c, int32_t n);
+typedef int32_t mputf4f(MFILE *mat, float *buf, int32_t v, int32_t l, int32_t c, int32_t n);
+
+typedef int32_t mgetf8f(MFILE *mat, double *buf, int32_t v, int32_t l, int32_t c, int32_t n);
+typedef int32_t mputf8f(MFILE *mat, double *buf, int32_t v, int32_t l, int32_t c, int32_t n);
+
 void matproc_guessfiletype(MFILE *mat);
 void matproc_init(MFILE *mat);
 int32_t matproc_filetype(const char *fmtname);

--- a/src/hdtv/rootext/mfile-root/mfile/src/mate_getput.c
+++ b/src/hdtv/rootext/mfile-root/mfile/src/mate_getput.c
@@ -31,7 +31,7 @@
 
 #define fpos(s) (((level * mat->lines + line) * mat->columns + col) * (s))
 
-int32_t mate_get(MFILE *mat, int32_t *buffer, uint32_t level, uint32_t line, uint32_t col, uint32_t num) {
+int32_t mate_get(MFILE *mat, int32_t *buffer, int32_t level, int32_t line, int32_t col, int32_t num) {
   int32_t nread = getle4(mat->ap, buffer, fpos(4) + 0x200, num);
   int32_t i;
 

--- a/src/hdtv/rootext/mfile-root/mfile/src/mate_getput.h
+++ b/src/hdtv/rootext/mfile-root/mfile/src/mate_getput.h
@@ -30,4 +30,4 @@
 #include "mfile.h"
 #include <stdint.h>
 
-int32_t mate_get(MFILE *mat, int32_t *buffer, uint32_t level, uint32_t line, uint32_t col, uint32_t num);
+int32_t mate_get(MFILE *mat, int32_t *buffer, int32_t level, int32_t line, int32_t col, int32_t num);

--- a/src/hdtv/rootext/mfile-root/mfile/src/oldmat_minfo.c
+++ b/src/hdtv/rootext/mfile-root/mfile/src/oldmat_minfo.c
@@ -46,9 +46,7 @@ static void guesslinescols(MFILE *mat, uint32_t size);
 
 char MAGIC_OLDMAT[] = "\nMatFmt: ";
 
-static void guessdatatype(mat, pos) MFILE *mat;
-uint32_t pos;
-{
+static void guessdatatype(MFILE *mat, uint32_t pos) {
   unsigned char buf[TESTBUFSIZE];
   int32_t nread;
   int32_t n1 = 0, n2 = 0, n3 = 0, n4 = 0;
@@ -130,9 +128,7 @@ uint32_t pos;
   }
 }
 
-static void guesslinescols(mat, size) MFILE *mat;
-uint32_t size;
-{
+static void guesslinescols(MFILE *mat, uint32_t size) {
   int32_t filetype = mat->filetype;
 
   if (filetype != MAT_INVALID) {
@@ -210,9 +206,7 @@ uint32_t size;
   }
 }
 
-static void checkformagic(mat, size) MFILE *mat;
-int32_t size;
-{
+static void checkformagic(MFILE *mat, int32_t size) {
   oldmat_header omh;
   uint32_t s = sizeof(omh);
   uint32_t l = strlen(MAGIC_OLDMAT);
@@ -225,8 +219,7 @@ int32_t size;
   msetfmt(mat, omh + l);
 }
 
-void oldmat_probe(mat) MFILE *mat;
-{
+void oldmat_probe(MFILE *mat) {
   uint32_t size = mat->ap->size;
 
   checkformagic(mat, size);
@@ -240,8 +233,7 @@ void oldmat_probe(mat) MFILE *mat;
   guesslinescols(mat, size);
 }
 
-void oldmat_init(mat) MFILE *mat;
-{
+void oldmat_init(MFILE *mat) {
   if (0 < mat->columns && mat->columns <= MAT_COLMAX) {
     int32_t filetype = mat->filetype;
     int32_t datatype = matproc_datatype(filetype);
@@ -284,9 +276,7 @@ void oldmat_init(mat) MFILE *mat;
   }
 }
 
-int32_t oldmat_uninit(mat)
-MFILE *mat;
-{
+int32_t oldmat_uninit(MFILE *mat) {
   if ((mat->status & MST_DIRTY) == 0)
     return 0;
 

--- a/src/hdtv/rootext/mfile-root/mfile/src/oldmat_minfo.c
+++ b/src/hdtv/rootext/mfile-root/mfile/src/oldmat_minfo.c
@@ -244,27 +244,30 @@ void oldmat_init(MFILE *mat) {
     mat->specinfo.i = elemsize;
     mat->version = OLDMAT_STD_VERSION;
 
+    // TODO:
+    // Casting function pointers with different argument types is theoretically undefined behavior (C11 6.3.2.3p1/p8).
+    // In this case, only pointer arguments are casted. Current compilers handle this just fine.
     switch (datatype) {
     case MAT_D_I2U:
-      mat->mgeti4f = getf;
-      mat->mputi4f = putf;
+      mat->mgeti4f = (mgeti4f *)getf;
+      mat->mputi4f = (mputi4f *)putf;
       break;
     case MAT_D_I2S:
-      mat->mgeti4f = getf;
-      mat->mputi4f = putf;
+      mat->mgeti4f = (mgeti4f *)getf;
+      mat->mputi4f = (mputi4f *)putf;
       break;
     case MAT_D_I4S:
-      mat->mgeti4f = getf;
-      mat->mputi4f = putf;
+      mat->mgeti4f = (mgeti4f *)getf;
+      mat->mputi4f = (mputi4f *)putf;
       break;
     case MAT_D_F4:
-      mat->mgetf4f = getf;
-      mat->mputf4f = putf;
+      mat->mgetf4f = (mgetf4f *)getf;
+      mat->mputf4f = (mputf4f *)putf;
       mat->version = 2;
       break;
     case MAT_D_F8:
-      mat->mgetf8f = getf;
-      mat->mputf8f = putf;
+      mat->mgetf8f = (mgetf8f *)getf;
+      mat->mputf8f = (mputf8f *)putf;
       mat->version = 2;
       break;
     default:

--- a/src/hdtv/rootext/mfile-root/mfile/src/trixi_getput.c
+++ b/src/hdtv/rootext/mfile-root/mfile/src/trixi_getput.c
@@ -34,7 +34,7 @@
 
 #define fpos(s) (((level * mat->lines + line) * mat->columns + col) * (s) + 512)
 
-int32_t trixi_get(MFILE *mat, int32_t *buffer, uint32_t level, uint32_t line, uint32_t col, uint32_t num) {
+int32_t trixi_get(MFILE *mat, int32_t *buffer, int32_t level, int32_t line, int32_t col, int32_t num) {
 
   return getle2(mat->ap, buffer, fpos(2), num);
 }

--- a/src/hdtv/rootext/mfile-root/mfile/src/trixi_getput.h
+++ b/src/hdtv/rootext/mfile-root/mfile/src/trixi_getput.h
@@ -30,4 +30,4 @@
 #include "mfile.h"
 #include <stdint.h>
 
-int32_t trixi_get(MFILE *mat, int32_t *buffer, uint32_t level, uint32_t line, uint32_t col, uint32_t num);
+int32_t trixi_get(MFILE *mat, int32_t *buffer, int32_t level, int32_t line, int32_t col, int32_t num);

--- a/src/hdtv/rootext/mfile-root/mfile/src/txt_getput.c
+++ b/src/hdtv/rootext/mfile-root/mfile/src/txt_getput.c
@@ -34,7 +34,7 @@
 #include "txt_getput.h"
 #include "txt_minfo.h"
 
-int32_t txt_get(MFILE *mat, int32_t *buffer, uint32_t level, uint32_t line, uint32_t col, uint32_t num) {
+int32_t txt_get(MFILE *mat, double *buffer, int32_t level, int32_t line, int32_t col, int32_t num) {
 
   double *dblp = (double *)mat->specinfo.p;
 
@@ -47,7 +47,7 @@ int32_t txt_get(MFILE *mat, int32_t *buffer, uint32_t level, uint32_t line, uint
   return num;
 }
 
-int32_t txt_put(MFILE *mat, int32_t *buffer, uint32_t level, uint32_t line, uint32_t col, uint32_t num) {
+int32_t txt_put(MFILE *mat, double *buffer, int32_t level, int32_t line, int32_t col, int32_t num) {
   double *dblp = (double *)mat->specinfo.p;
 
   /*  if (dblp == NULL) return -1; */

--- a/src/hdtv/rootext/mfile-root/mfile/src/txt_getput.h
+++ b/src/hdtv/rootext/mfile-root/mfile/src/txt_getput.h
@@ -31,6 +31,6 @@
 #include "mfile.h"
 #include <stdint.h>
 
-extern int32_t txt_get(MFILE *mat, int32_t *buffer, uint32_t level, uint32_t line, uint32_t col, uint32_t num);
-extern int32_t txt_put(MFILE *mat, int32_t *buffer, uint32_t level, uint32_t line, uint32_t col, uint32_t num);
+extern int32_t txt_get(MFILE *mat, double *buffer, int32_t level, int32_t line, int32_t col, int32_t num);
+extern int32_t txt_put(MFILE *mat, double *buffer, int32_t level, int32_t line, int32_t col, int32_t num);
 extern int32_t txt_flush(MFILE *mat);


### PR DESCRIPTION
**The content of the PR has changed due to a better plan**

I want to have a easy to understand and modern CMakeLists.txt for building mfile as stand alone project. This is in preparation of building it as part of the python package (see #59)

**new**
Now this PR contains also patches to build mfile with the latest GCC and Clang compilers. Those patches are similar to #56 but without loosing the type information in the pointers.

#### Commit message**
This is done in preparation for building mfile as stand alone library.
It has currently no effect on building HDTV.

Dump the target C version to C11

---

#### original / outdated
This is another patch towards a reducing the C/C++ code and have a better loading and integration of it.
The mfile library is independent of the Cern ROOT library. My plan is to build it during the creation of the python package and ship it as part of the wheel. Then load it via ROOT. The mfile-root C++ code could then be loaded via the CERN CLING C++ interpreter. This would eliminate the need of building the mfile-root shared object with --rebuild-usr.

@janmayer  @op, do you see this as viable plan?

This is a first step in separating the CMake files.

#### Commit message
This is a partial revert of 8cf7b97e32324426be2d42c3941a3c83b769badf. The difference is that mfile is now build and linked as static library into mfile-root and does not need to be located at runtime.

