### PR TITLE
Fix X server issues in Docker, Exit after `--rebuild-usr` / `--rebuild-sys`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM rootproject/root:6.34.00-ubuntu24.04
 
 LABEL name="hdtv"
 
-ENV PATH="$PATH:/root/.local/bin"
+ENV PATH="/root/.local/bin:$PATH"
 
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends pipx xvfb && \
@@ -11,9 +11,9 @@ RUN apt-get update -y && \
 WORKDIR /install
 COPY . /install
 
-RUN python3 -m pipx install . && \
-    bash -c "Xvfb :0 -screen 0 1024x768x16 &" && \
-    DISPLAY=:0 hdtv --rebuild-usr --execute exit
+RUN bash -c "Xvfb :99 -screen 0 1024x768x16 &" && \
+    python3 -m pipx install . && \
+    DISPLAY=:99 hdtv --rebuild-usr --execute exit
 
 WORKDIR /work
 CMD hdtv

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,15 +5,14 @@ LABEL name="hdtv"
 ENV PATH="/root/.local/bin:$PATH"
 
 RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends pipx xvfb && \
+    apt-get install -y --no-install-recommends pipx && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /install
 COPY . /install
 
-RUN bash -c "Xvfb :99 -screen 0 1024x768x16 &" && \
-    python3 -m pipx install . && \
-    DISPLAY=:99 hdtv --rebuild-usr --execute exit
+RUN python3 -m pipx install . && \
+    hdtv --rebuild-usr
 
 WORKDIR /work
 CMD hdtv

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,5 @@ RUN pipx install /hdtv-src && \
     rm -rf /hdtv-src
 
 WORKDIR /work
-CMD hdtv
+
+ENTRYPOINT ["hdtv"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,17 +2,21 @@ FROM rootproject/root:6.34.00-ubuntu24.04
 
 LABEL name="hdtv"
 
-ENV PATH="/root/.local/bin:$PATH"
+# TODO: When updating to a ubuntu26.04 based image, the ENV
+#       can be removed by giving pipx the `--global` option.
+#       https://pipx.pypa.io/stable/installation/
+ENV PIPX_HOME=/opt/pipx \
+    PIPX_BIN_DIR=/usr/local/bin
 
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends pipx && \
     rm -rf /var/lib/apt/lists/*
 
-WORKDIR /install
-COPY . /install
+COPY . /hdtv-src
 
-RUN python3 -m pipx install . && \
-    hdtv --rebuild-usr
+RUN pipx install /hdtv-src && \
+    hdtv --rebuild-sys && \
+    rm -rf /hdtv-src
 
 WORKDIR /work
 CMD hdtv

--- a/README.md
+++ b/README.md
@@ -75,7 +75,13 @@ docker build --tag hdtv .
 On Linux and MacOS, no further installation is required and in the directory with your project you will be able to use HDTV with:
 
 ```sh
-docker run -e DISPLAY=${DISPLAY} -v /tmp/.X11-unix:/tmp/.X11-unix -v $(pwd):/work -it hdtv
+docker run -e DISPLAY=${DISPLAY} -v /tmp/.X11-unix:/tmp/.X11-unix -v ${PWD}:/work -it hdtv
+```
+
+If your X server requires authorization, pass the .Xauthority file to the container.
+```sh
+
+docker run -e DISPLAY=${DISPLAY} -v /tmp/.X11-unix:/tmp/.X11-unix -v ${PWD}:/work -v ${XAUTHORITY}:/root/.Xauthority -it hdtv
 ```
 
 When using SELinux, the additional argument `--security-opt label=type:container_runtime_t` is required (before `-it`).

--- a/README.md
+++ b/README.md
@@ -78,6 +78,11 @@ On Linux and MacOS, no further installation is required and in the directory wit
 docker run -e DISPLAY=${DISPLAY} -v /tmp/.X11-unix:/tmp/.X11-unix -v ${PWD}:/work -it hdtv
 ```
 
+CLI arguments can be passed directly e.g.
+```sh
+docker run ... -it hdtv --help
+```
+
 If your X server requires authorization, pass the .Xauthority file to the container.
 ```sh
 

--- a/src/hdtv/app.py
+++ b/src/hdtv/app.py
@@ -115,7 +115,7 @@ class App:
                 hdtv.rootext.dlmgr.sysdir, libraries=args.rebuildsys or None
             )
 
-        if args.rebuildusr or args.rebuildsys:
+        if args.rebuildusr is not None or args.rebuildsys is not None:
             sys.exit(0)
 
         check_root_version()


### PR DESCRIPTION
Fix #55

I've added a 2nd patch which solves the problem but changes behavior.

**1st patch**
When building the container, an X server running on the host can interfere with the Xvfb server running inside the container. Don't ask my why. Using a different DISPLAY for the Xvfb server solves this.

Additionally, the X server of the host might require authorization. Add a corresponding note to the README.md.

**2nd patch**
Exit HDTV after `--rebuild-usr` / `--rebuild-sys`
    
When using `--rebuild-usr` or `--rebuild-sys` with an argument, e.g. `fit`, the given rootext is build and HDTV exits. When using no argument, so for building all rootexts, HDTV runs normally after building them.
This behavior was introduced in [1] and moved to its current location in [2].
    
Unify the behavior and exit HDTV in any case when `--rebuild-usr` or `--rebuild-sys` is given.
    
This fixes also the problem with needing X11 to build the rootexts in Docker.

**3rd patch**
Use `--rebuild-sys` when building the container. This makes the rootext better accessible when the container is mapped to another user.

**4th patch**
Use ENTRYPOINT to start HDTV. This enables to pass cli arguments direct to HDTV. E.g.: `docker run ... -it hdtv --help`
    

[1] 2282d22f: Better setup, pip compatible, better ROOT library handling...
[2] c4f98ef0: Replace bin/hdtv by hdtv.app:App() entrypoint
