### PR TITLE
Add headless mode

### DIFF
--- a/data/completions/_hdtv
+++ b/data/completions/_hdtv
@@ -3,6 +3,7 @@
 _arguments \
     {'(--batch)-b','(-b)--batch'}'[Open and execute HDTV batchfile]:batchfile:_files'\
     {'(--execute)-e','(-e)--execute'}'[Execute HDTV command(s)]:commands'\
+    '--headless[Execute HDTV without opening the GUI]'\
     {'(--help)-h','(-h)--help'}'[Show help message and exit]'\
     '--rebuild-usr[Rebuild ROOT-loadable libraries for the current user]'\
     '--rebuild-sys[Rebuild ROOT-loadable libraries for all users]'\

--- a/data/completions/hdtv
+++ b/data/completions/hdtv
@@ -4,7 +4,7 @@ _hdtv()
     COMPREPLY=()
     cur="${COMP_WORDS[COMP_CWORD]}"
     prev="${COMP_WORDS[COMP_CWORD-1]}"
-    opts="--batch --execute --help --version --rebuild-usr --rebuild-sys"
+    opts="--batch --execute --headless --help --version --rebuild-usr --rebuild-sys"
 
     if [[ ${prev} == --batch ]] || [[ ${prev} == -b ]]; then
         _filedir

--- a/doc/guide/hdtv.rst
+++ b/doc/guide/hdtv.rst
@@ -32,6 +32,9 @@ OPTIONS
 --batch *batchfile*, -b *batchfile*
     Open and execute hdtv batchfile
 
+--headless
+    Execute HDTV without opening the GUI
+
 --execute *commands*, -e *commands*
     Execute hdtv command(s)
 

--- a/src/hdtv/app.py
+++ b/src/hdtv/app.py
@@ -120,6 +120,10 @@ class App:
 
         check_root_version()
 
+        if args.headless:
+            from hdtv.util import monkey_patch_ui
+            monkey_patch_ui()
+
         # Import core modules
         import hdtv.cmdline
         import hdtv.session
@@ -205,6 +209,11 @@ class App:
             nargs="*",
             dest="rebuildsys",
             help="Rebuild ROOT-loadable libraries for all users",
+        )
+        parser.add_argument(
+            "--headless",
+            action="store_true",
+            help="Execute HDTV without opening the GUI",
         )
         return parser.parse_args(args)
 


### PR DESCRIPTION
Add a CLI option, `--headless`, which monkey patches the GUI like the tests to use the headless dummy one.

Having this is useful for running HDTV dozens of times from a script.

---

I just saw the `monkey_patch_ui` function and had the idea to use it.
I'm open to create a real patch or discard this.

---

@h-mayr : This was on our wishlist. Can you test is?