### PR TITLE
Fix versioningit config

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
-hdtv/_version.py export-subst
+pyproject.toml export-subst
 * text=auto eol=lf
 
 #

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,13 @@ hdtv = ["share/*"]
 "share/bash-completion/completions" = ["data/completions/hdtv"]
 "share/applications" = ["data/hdtv.desktop"]
 
+[tool.versioningit.vcs]
+method = "git-archive"
+describe-subst = "$Format:%(describe:tags)$"
+# A clone or fork with tags is needed to get the correct version information.
+# The fixed `default-tag` is used when no git tag is available.
+default-tag = "0000"
+
 [tool.versioningit.format]
 distance = "{base_version}+{distance}.{vcs}{rev}"
 dirty = "{base_version}+{distance}.{vcs}{rev}.dirty"


### PR DESCRIPTION
The uv based development setup failed when the repository was shallowly cloned or came from a fork without git tags. Add the default-tag of 0000 to be able to build the project. It will then produce a version such as `hdtv-0000+1279.g4af31e7.dirty`.

This also fixes the version information when creating a git archive.

---

This happened in #61 